### PR TITLE
Fix async blur handler to avoid SyntaxError

### DIFF
--- a/js/main.mjs
+++ b/js/main.mjs
@@ -125,7 +125,7 @@ function wireUI(){
     }
   });
 
-  document.addEventListener('blur', (e)=>{
+  document.addEventListener('blur', async (e)=>{
     if (e.target instanceof HTMLElement) {
       console.debug('[FlowSim] blur', e.target.tagName, e.target.dataset);
       if (e.target.matches('[data-state-name]')) { const id = e.target.dataset.id; const name = e.target.textContent.trim(); if (name) renameState(id, name); }


### PR DESCRIPTION
## Summary
- mark blur event listener async to allow awaiting dynamic imports

## Testing
- `node --check js/main.mjs`


------
https://chatgpt.com/codex/tasks/task_e_68bee4f23e488331be672e273bbb0b65