### PR TITLE
Derive workgroup from cell state

### DIFF
--- a/js/model.mjs
+++ b/js/model.mjs
@@ -22,10 +22,8 @@ export function addGroup(name='Workgroup'){ state.groups.push({id:uid(), name});
 export function renameGroup(id, name){ const g=state.groups.find(x=>x.id===id); if(!g) return; g.name=name||g.name; renderSidebar(); renderGrid(); saveSnapshot(); }
 export function deleteGroup(id){
   const g = state.groups.find(x=>x.id===id); if(!g) return;
-  if (!confirm(`Delete workgroup “${g.name}”? Items in this row will move to first workgroup.`)) return;
+  if (!confirm(`Delete workgroup “${g.name}”?`)) return;
   const remaining = state.groups.filter(x => x.id!==id); if (remaining.length===0){ alert('Cannot delete the last workgroup.'); return; }
-  const target = remaining[0].id;
-  for (const it of state.items.values()){ if (it.groupId===id){ it.groupId=target; } }
   state.groups = remaining; renderSidebar(); renderGrid(); saveSnapshot();
 }
 export function moveGroup(id, delta){
@@ -33,8 +31,8 @@ export function moveGroup(id, delta){
   const [gp]=state.groups.splice(i,1); state.groups.splice(j,0,gp); renderSidebar(); renderGrid(); saveSnapshot();
 }
 
-export function newItem({type='Story', size=3, complexity=5, stateId, groupId}){
+export function newItem({type='Story', size=3, complexity=5, stateId}){
   const id = uid(); const now = state.sim.day;
-  const it = { id, type, size, complexity, stateId, groupId, createdAt: now, stateEnteredAt: now };
+  const it = { id, type, size, complexity, stateId, createdAt: now, stateEnteredAt: now };
   state.items.set(id, it); return it;
 }

--- a/js/ui/grid.mjs
+++ b/js/ui/grid.mjs
@@ -1,5 +1,5 @@
 // Grid rendering + DnD
-import { state, TYPE_COLORS, canWork, getCell } from '../store.mjs';
+import { state, TYPE_COLORS, getCell, groupFor } from '../store.mjs';
 
 const $ = s => document.querySelector(s);
 const h = (tag, props={}, children=[]) => {
@@ -37,14 +37,13 @@ export function renderGrid(){
         const id = e.dataTransfer.getData('text/plain');
         const it = state.items.get(id); if(!it) return;
         const prev = it.stateId;
-        const groupName = state.groups.find(x=>x.id===g.id)?.name;
-        const stateName = state.states.find(x=>x.id===s.id)?.name;
-        if (!canWork(groupName, stateName, it.type)){
-          console.debug('[FlowSim] drop blocked', {groupName, stateName, type: it.type});
+        const expected = groupFor(s.id, it.type);
+        if (expected !== g.id){
+          console.debug('[FlowSim] drop blocked', {expected, target:g.id, stateId:s.id, type:it.type});
           cell.animate([{transform:'translateY(0)'},{transform:'translateY(-3px)'},{transform:'translateY(0)'}], {duration:220});
           return;
         }
-        it.stateId = s.id; it.groupId = g.id;
+        it.stateId = s.id;
         if (prev !== s.id) it.stateEnteredAt = state.sim.day;
         renderItemsIntoGrid();
         localStorage.setItem('flowsim.touch','1');
@@ -62,7 +61,9 @@ export function renderItemsIntoGrid(){
   grid.querySelectorAll('.cell').forEach(c => c.querySelector('.empty') ? null : c.appendChild(Object.assign(document.createElement('div'), {className:'empty', textContent:'Drop items here…'})));
   grid.querySelectorAll('.cell').forEach(c => { c.querySelectorAll('.wi').forEach(el=>el.remove()); });
   for (const it of state.items.values()){
-    const selector = `.cell[data-state-id="${it.stateId}"][data-group-id="${it.groupId}"]`;
+    const gId = groupFor(it.stateId, it.type);
+    if (!gId) continue;
+    const selector = `.cell[data-state-id="${it.stateId}"][data-group-id="${gId}"]`;
     const cell = grid.querySelector(selector); if (!cell) continue;
     const empty = cell.querySelector('.empty'); if (empty) empty.remove();
     cell.appendChild(renderItem(it));

--- a/js/ui/modal.mjs
+++ b/js/ui/modal.mjs
@@ -1,5 +1,5 @@
 // New Workitem modal + Cell config modal
-import { state, canWork, getCell, setCell } from '../store.mjs';
+import { state, getCell, setCell, groupFor } from '../store.mjs';
 import { newItem } from '../model.mjs';
 import { renderSidebar } from './sidebar.mjs';
 import { renderItemsIntoGrid, renderGrid } from './grid.mjs';
@@ -23,7 +23,6 @@ export function showAddItemModal(){
       </div>
       <div class="formRow">
         <label>Initial State <select name="state" id="stateSelect"></select></label>
-        <label>Workgroup <select name="group" id="groupSelect"></select></label>
       </div>
       <menu>
         <button value="cancel" class="btn ghost">Cancel</button>
@@ -33,20 +32,14 @@ export function showAddItemModal(){
   const form = dlg.querySelector('#itemForm');
   const typeSel = form.querySelector('select[name="type"]');
   const stSel = form.querySelector('#stateSelect');
-  const gpSel = form.querySelector('#groupSelect');
   stSel.innerHTML=''; state.states.forEach(s=> stSel.appendChild(new Option(s.name, s.id)));
-  gpSel.innerHTML=''; state.groups.forEach(g=> gpSel.appendChild(new Option(g.name, g.id)));
 
   function refreshFilters(){
     const type = typeSel.value;
-    const allowedStates = state.states.filter(s => state.groups.some(g => canWork(g.name, s.name, type)));
+    const allowedStates = state.states.filter(s => groupFor(s.id, type));
     const curS = stSel.value; stSel.innerHTML=''; allowedStates.forEach(s=> stSel.appendChild(new Option(s.name, s.id)));
     if (allowedStates.some(s=>s.id===curS)) stSel.value=curS;
-    const sName = state.states.find(s=>s.id===stSel.value)?.name;
-    const allowedGroups = state.groups.filter(g => canWork(g.name, sName, type));
-    const curG = gpSel.value; gpSel.innerHTML=''; allowedGroups.forEach(g=> gpSel.appendChild(new Option(g.name, g.id)));
-    if (allowedGroups.some(g=>g.id===curG)) gpSel.value=curG;
-    form.querySelector('#confirmAdd').disabled = !(allowedStates.length && allowedGroups.length);
+    form.querySelector('#confirmAdd').disabled = !allowedStates.length;
   }
   typeSel.addEventListener('change', refreshFilters);
   stSel.addEventListener('change', refreshFilters);
@@ -56,9 +49,9 @@ export function showAddItemModal(){
   form.addEventListener('submit', e => e.preventDefault());
   form.querySelector('menu .primary').addEventListener('click', () => {
     const fd = new FormData(form);
-    const type = fd.get('type'); const stateId = fd.get('state'); const groupId = fd.get('group');
-    if (!type || !stateId || !groupId) return;
-    newItem({ type, size: Number(fd.get('size')), complexity: Number(fd.get('complexity')), stateId, groupId });
+    const type = fd.get('type'); const stateId = fd.get('state');
+    if (!type || !stateId) return;
+    newItem({ type, size: Number(fd.get('size')), complexity: Number(fd.get('complexity')), stateId });
     renderItemsIntoGrid(); saveSnapshot(); dlg.close();
   });
   form.querySelector('menu .ghost').addEventListener('click', () => dlg.close());


### PR DESCRIPTION
## Summary
- remove workgroup field from work items
- derive workgroup based on item state and cell configuration
- simplify item creation and random seeding to use derived workgroup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bee779c9fc8331ae6b2241d3865d9b