### PR TITLE
feat: configurable work item types

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
         <button id="addGroupBtn" class="btn small" data-add-group>+ Workgroup</button>
       </section>
       <section>
+        <h2>Types</h2>
+        <ul id="typeList" class="list"></ul>
+      </section>
+      <section>
         <h2>Simulation</h2>
         <div class="simInfo">Day: <strong id="simDay">0</strong> • Items: <strong id="itemCount">0</strong></div>
       </section>

--- a/js/ui/grid.mjs
+++ b/js/ui/grid.mjs
@@ -27,7 +27,8 @@ export function renderGrid(){
     for (const s of state.states){
       const cell = h('div', { class:'cell', dataset:{ stateId: s.id, groupId: g.id } });
       const cfg = getCell(g.id, s.id);
-      if (!cfg.allowedTypes || cfg.allowedTypes.length === 0) cell.classList.add('disallowed');
+      const allowed = (cfg.allowedTypes||[]).filter(t=>state.types.includes(t));
+      if (allowed.length === 0) cell.classList.add('disallowed');
       const tools = h('div', { class:'cell-tools' }, [ h('button', { class:'tool', dataset:{ editCell:'', stateId: s.id, groupId: g.id } }, '⚙︎') ]);
       cell.appendChild(tools);
       cell.addEventListener('dragover', e => { e.preventDefault(); cell.classList.add('dropTarget'); });

--- a/js/ui/modal.mjs
+++ b/js/ui/modal.mjs
@@ -14,9 +14,7 @@ export function showAddItemModal(){
       <h3>New Workitem</h3>
       <div class="formRow">
         <label>Type
-          <select name="type" required>
-            <option>Epic</option><option>Feature</option><option>Story</option><option>Bug</option>
-          </select>
+          <select name="type" required id="typeSelect"></select>
         </label>
         <label>Size <input name="size" type="number" min="1" max="20" value="3" required /></label>
         <label>Complexity <input name="complexity" type="number" min="1" max="20" value="5" required /></label>
@@ -31,11 +29,12 @@ export function showAddItemModal(){
       </menu>
     </form>`;
   const form = dlg.querySelector('#itemForm');
-  const typeSel = form.querySelector('select[name="type"]');
+  const typeSel = form.querySelector('#typeSelect');
   const stSel = form.querySelector('#stateSelect');
   const gpSel = form.querySelector('#groupSelect');
   stSel.innerHTML=''; state.states.forEach(s=> stSel.appendChild(new Option(s.name, s.id)));
   gpSel.innerHTML=''; state.groups.forEach(g=> gpSel.appendChild(new Option(g.name, g.id)));
+  typeSel.innerHTML=''; state.types.forEach(t=> typeSel.appendChild(new Option(t, t)));
 
   function refreshFilters(){
     const type = typeSel.value;
@@ -68,7 +67,7 @@ export function showCellConfigModal(groupId, stateId){
   const dlg = document.getElementById('cellModal');
   const cfg = getCell(groupId, stateId);
   const st = state.states.find(s=>s.id===stateId); const g = state.groups.find(x=>x.id===groupId);
-  const allTypes = ['Epic','Feature','Story','Bug'];
+  const allTypes = state.types;
   dlg.innerHTML = `
     <form id="cellForm" method="dialog">
       <h3>Cell Settings — ${g?.name||'Group'} × ${st?.name||'State'}</h3>

--- a/js/ui/sidebar.mjs
+++ b/js/ui/sidebar.mjs
@@ -1,5 +1,6 @@
 // Sidebar lists for states & groups (inline editable, tool buttons)
-import { state, saveSnapshot, getWorkgroupSettings } from '../store.mjs';
+import { state, saveSnapshot, getWorkgroupSettings, ALL_TYPES } from '../store.mjs';
+import { renderGrid } from './grid.mjs';
 
 const $ = s => document.querySelector(s);
 const h = (tag, props={}, children=[]) => {
@@ -52,4 +53,20 @@ export function renderSidebar(){
     ]);
     groupList.appendChild(li);
   });
+  // types
+  const typeList = $('#typeList'); if (typeList){ typeList.innerHTML='';
+    ALL_TYPES.forEach(t=>{
+      const li = h('li', {}, [
+        h('label', { style:'display:flex;align-items:center;gap:6px' }, [
+          h('input', { type:'checkbox', checked: state.types.includes(t), onchange:(e)=>{
+            if (e.target.checked){ if(!state.types.includes(t)) state.types.push(t); }
+            else { state.types = state.types.filter(x=>x!==t); }
+            renderGrid(); saveSnapshot();
+          }}),
+          t
+        ])
+      ]);
+      typeList.appendChild(li);
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- allow choosing active work item types and persist selection in snapshots and config files
- add sidebar section for toggling item types and update modals accordingly
- have grid and random item creation respect selected types

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check js/store.mjs js/main.mjs js/ui/sidebar.mjs js/ui/modal.mjs js/ui/grid.mjs js/model.mjs js/sim.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68bee80047bc83319c45d56fa1cc178f