### PR TITLE
Add item decomposition settings to cells

### DIFF
--- a/js/store.mjs
+++ b/js/store.mjs
@@ -25,7 +25,7 @@ export function canWork(groupName, stateName, type){
 }
 
 // ---- Extended config: per-cell rules and workgroup schedule
-// cells: Map key = `${groupId}|${stateId}` -> { allowedTypes:[], wip: null, capacityMode:'items'|'complexity', capacityValue:null, exit:{nextStateId:null, threshold:null, highNextStateId:null, doneOnExit:false} }
+// cells: Map key = `${groupId}|${stateId}` -> { allowedTypes:[], wip: null, capacityMode:'items'|'complexity', capacityValue:null, exit:{nextStateId:null, threshold:null, highNextStateId:null, doneOnExit:false}, decompose:null|{threshold:null, splitRatio:null} }
 export const cells = new Map();
 // workgroupSettings: Map groupId -> { startDay:0, frequency:7 }
 export const workgroupSettings = new Map();
@@ -33,13 +33,15 @@ export const workgroupSettings = new Map();
 export function cellKey(groupId, stateId){ return `${groupId}|${stateId}`; }
 export function getCell(groupId, stateId){
   const k = cellKey(groupId, stateId);
-  if (!cells.has(k)) cells.set(k, { allowedTypes:[], wip:null, capacityMode:'items', capacityValue:null, exit:{ nextStateId:null, threshold:null, highNextStateId:null, doneOnExit:false } });
+  if (!cells.has(k)) cells.set(k, { allowedTypes:[], wip:null, capacityMode:'items', capacityValue:null, exit:{ nextStateId:null, threshold:null, highNextStateId:null, doneOnExit:false }, decompose:null });
   return cells.get(k);
 }
 export function setCell(groupId, stateId, data){
   const k = cellKey(groupId, stateId);
   const cur = getCell(groupId, stateId);
-  cells.set(k, { ...cur, ...data, exit: { ...cur.exit, ...(data.exit||{}) } });
+  const merged = { ...cur, ...data, exit: { ...cur.exit, ...(data.exit||{}) } };
+  if ('decompose' in data) merged.decompose = data.decompose ? { ...(cur.decompose||{}), ...data.decompose } : null;
+  cells.set(k, merged);
 }
 
 export function getWorkgroupSettings(groupId){

--- a/js/ui/modal.mjs
+++ b/js/ui/modal.mjs
@@ -99,6 +99,17 @@ export function showCellConfigModal(groupId, stateId){
         </div>
         <div class="formRow">
           <label style="display:inline-flex;gap:6px;align-items:center">
+            <input type="checkbox" name="decompose" ${cfg.decompose?'checked':''}/> Split items above complexity
+          </label>
+          <label class="decomposeOpts" style="display:${cfg.decompose?'':'none'}">Threshold
+            <input name="threshold" type="number" min="0" value="${cfg.decompose?.threshold??''}"/>
+          </label>
+          <label class="decomposeOpts" style="display:${cfg.decompose?'':'none'}">Children per point
+            <input name="splitRatio" type="number" min="1" value="${cfg.decompose?.splitRatio??''}"/>
+          </label>
+        </div>
+        <div class="formRow">
+          <label style="display:inline-flex;gap:6px;align-items:center">
             <input type="checkbox" name="done" ${cfg.exit?.doneOnExit?'checked':''}/> Items leaving this state are considered done
           </label>
         </div>
@@ -116,14 +127,22 @@ export function showCellConfigModal(groupId, stateId){
     const types = fd.getAll('type');
     const wip = fd.get('wip'); const capMode = fd.get('capMode'); const capVal = fd.get('capVal');
     const exitNext = fd.get('exitNext'); const thr = fd.get('thr'); const exitHigh = fd.get('exitHigh'); const done = fd.get('done')==='on';
+    const decompose = fd.get('decompose')==='on'; const thr2 = fd.get('threshold'); const splitRatio = fd.get('splitRatio');
     setCell(groupId, stateId, {
       allowedTypes: types,
       wip: wip===''?null:Number(wip),
       capacityMode: capMode,
       capacityValue: capVal===''?null:Number(capVal),
-      exit: { nextStateId: exitNext||null, threshold: thr===''?null:Number(thr), highNextStateId: exitHigh||null, doneOnExit: done }
+      exit: { nextStateId: exitNext||null, threshold: thr===''?null:Number(thr), highNextStateId: exitHigh||null, doneOnExit: done },
+      decompose: decompose ? { threshold: thr2===''?null:Number(thr2), splitRatio: splitRatio===''?null:Number(splitRatio) } : null
     });
     renderGrid(); saveSnapshot(); dlg.close();
   });
   form.querySelector('menu .ghost').addEventListener('click', () => dlg.close());
+
+  const decChk = form.querySelector('input[name="decompose"]');
+  const decOpts = form.querySelectorAll('.decomposeOpts');
+  function toggleDecompose(){ decOpts.forEach(el => el.style.display = decChk.checked ? '' : 'none'); }
+  decChk.addEventListener('change', toggleDecompose);
+  toggleDecompose();
 }


### PR DESCRIPTION
## Summary
- allow cells to enable "Split items above complexity" option
- capture threshold and children-per-point ratio, persisted with cell config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bef0899938833199434c1cf27b9315