### PR TITLE
Implement per-day work item progression

### DIFF
--- a/js/engine.mjs
+++ b/js/engine.mjs
@@ -1,0 +1,81 @@
+// Simulation engine: per-day processing of work items
+import { state, getCell, getWorkgroupSettings, groupFor } from './store.mjs';
+import { newItem } from './model.mjs';
+import { renderItemsIntoGrid } from './ui/grid.mjs';
+
+// Process a single simulation day
+export function processDay(day){
+  let changed = false;
+  for (const g of state.groups){
+    const sched = getWorkgroupSettings(g.id);
+    if (day < sched.startDay) continue;
+    if ((day - sched.startDay) % sched.frequency !== 0) continue; // not a working day for this group
+
+    for (const s of state.states){
+      const cfg = getCell(g.id, s.id);
+      let items = Array.from(state.items.values()).filter(it => it.stateId === s.id && groupFor(s.id, it.type) === g.id);
+      if (items.length === 0) continue;
+
+      // Decompose oversized items before processing
+      if (cfg.decompose && cfg.decompose.threshold != null){
+        for (const it of [...items]){
+          if (it.complexity > cfg.decompose.threshold){
+            const ratio = cfg.decompose.splitRatio || 2;
+            const childComplexity = Math.ceil(it.complexity / ratio);
+            const childSize = Math.ceil(it.size / ratio);
+            for (let i=0;i<ratio;i++){
+              const child = newItem({ type: it.type, size: childSize, complexity: childComplexity, stateId: it.stateId });
+              child.createdAt = it.createdAt;
+              child.stateEnteredAt = it.stateEnteredAt;
+              child.remaining = child.complexity;
+            }
+            state.items.delete(it.id);
+            changed = true;
+          }
+        }
+        // refresh items after decomposition
+        items = Array.from(state.items.values()).filter(it => it.stateId === s.id && groupFor(s.id, it.type) === g.id);
+      }
+
+      // Sort items by time in state for fairness
+      items.sort((a,b)=>a.stateEnteredAt - b.stateEnteredAt);
+
+      const wipLimit = cfg.wip ?? Infinity;
+      let capacityLeft = cfg.capacityValue ?? Infinity;
+      let processed = 0;
+
+      for (const it of items){
+        if (processed >= wipLimit) break;
+        if (capacityLeft <= 0) break;
+        if (it.remaining === undefined) it.remaining = it.complexity;
+
+        if (cfg.capacityMode === 'complexity'){
+          const work = Math.min(it.remaining, capacityLeft);
+          it.remaining -= work;
+          capacityLeft -= work;
+        }else{ // 'items'
+          it.remaining -= 1;
+          capacityLeft -= 1;
+        }
+        processed++;
+        changed = true;
+
+        if (it.remaining <= 0){
+          const exit = cfg.exit || {};
+          let target = exit.nextStateId;
+          if (exit.threshold != null && exit.highNextStateId && it.complexity >= exit.threshold){
+            target = exit.highNextStateId;
+          }
+          if (exit.doneOnExit){
+            state.items.delete(it.id);
+          }else if (target){
+            it.stateId = target;
+            it.stateEnteredAt = state.sim.day;
+            it.remaining = it.complexity;
+          }
+        }
+      }
+    }
+  }
+  if (changed) renderItemsIntoGrid();
+}

--- a/js/main.mjs
+++ b/js/main.mjs
@@ -29,9 +29,14 @@ function importJSON(file){
     try{
       const data = JSON.parse(reader.result);
       state.sim.day = Number(data.sim?.day ?? 0);
+      state.sim.nextDay = Math.floor(state.sim.day) + 1;
       state.states = data.states ?? [];
       state.groups = data.groups ?? [];
-      state.items = new Map((data.items ?? []).map(it => { const { groupId, ...rest } = it || {}; return [rest.id, rest]; }));
+      state.items = new Map((data.items ?? []).map(it => {
+        const { groupId, ...rest } = it || {};
+        if (rest.remaining === undefined) rest.remaining = rest.complexity;
+        return [rest.id, rest];
+      }));
       // cells & workgroup settings
       const store = await import('./store.mjs');
       store.cells.clear(); (data.cells||[]).forEach(([k,v])=> store.cells.set(k,v));
@@ -59,7 +64,14 @@ async function saveLocalConfig(name){
 }
 async function loadLocalConfig(name){
   const all = JSON.parse(localStorage.getItem('flowsim.saved')||'{}'); const data=all[name]; if(!data) return false;
-  state.sim.day = Number(data.sim?.day ?? 0); state.states = data.states ?? []; state.groups = data.groups ?? []; state.items = new Map((data.items ?? []).map(it => { const { groupId, ...rest } = it || {}; return [rest.id, rest]; }));
+  state.sim.day = Number(data.sim?.day ?? 0);
+  state.sim.nextDay = Math.floor(state.sim.day) + 1;
+  state.states = data.states ?? []; state.groups = data.groups ?? [];
+  state.items = new Map((data.items ?? []).map(it => {
+    const { groupId, ...rest } = it || {};
+    if (rest.remaining === undefined) rest.remaining = rest.complexity;
+    return [rest.id, rest];
+  }));
   const store = await import('./store.mjs');
   state.types = data.types ?? [...store.ALL_TYPES];
   store.cells.clear(); (data.cells||[]).forEach(([k,v])=> store.cells.set(k,v));

--- a/js/model.mjs
+++ b/js/model.mjs
@@ -33,6 +33,6 @@ export function moveGroup(id, delta){
 
 export function newItem({type='Story', size=3, complexity=5, stateId}){
   const id = uid(); const now = state.sim.day;
-  const it = { id, type, size, complexity, stateId, createdAt: now, stateEnteredAt: now };
+  const it = { id, type, size, complexity, remaining: complexity, stateId, createdAt: now, stateEnteredAt: now };
   state.items.set(id, it); return it;
 }

--- a/js/sim.mjs
+++ b/js/sim.mjs
@@ -1,16 +1,23 @@
 // Simulation loop
 import { state } from './store.mjs';
+import { processDay } from './engine.mjs';
 
 const $ = s => document.querySelector(s);
 
 export function startSim(){
+  state.sim.nextDay = Math.floor(state.sim.day) + 1;
   const raf = (now)=>{
     const dt = now - state.sim.lastTick;
     state.sim.lastTick = now;
     if (state.sim.playing){
       const deltaDays = (dt / 1000) * state.sim.speed;
       state.sim.day += deltaDays;
-      $('#simDay').textContent = String(Math.floor(state.sim.day));
+      const curDay = Math.floor(state.sim.day);
+      while (state.sim.nextDay <= curDay){
+        processDay(state.sim.nextDay);
+        state.sim.nextDay++;
+      }
+      $('#simDay').textContent = String(curDay);
       document.querySelectorAll('.wi').forEach(el=>{
         const id = el.dataset.id;
         const it = window.__items?.get(id); if(!it) return;

--- a/js/store.mjs
+++ b/js/store.mjs
@@ -1,6 +1,6 @@
 // Global state + persistence
 export const state = {
-  sim: { playing:false, day:0, speed:1, lastTick: performance.now() },
+  sim: { playing:false, day:0, speed:1, lastTick: performance.now(), nextDay:1 },
   states: [],          // [{id,name}]
   groups: [],          // [{id,name}]
   items: new Map(),    // id -> item
@@ -87,10 +87,12 @@ export function loadSnapshot(){
   try{
     const s = JSON.parse(raw);
     state.sim.day = s.sim?.day ?? 0;
+    state.sim.nextDay = Math.floor(state.sim.day) + 1;
     state.states = s.states ?? [];
     state.groups = s.groups ?? [];
     state.items = new Map((s.items ?? []).map(it => {
       const { groupId, ...rest } = it || {};
+      if (rest.remaining === undefined) rest.remaining = rest.complexity;
       return [rest.id, rest];
     }));
     // load cells & workgroupSettings if present


### PR DESCRIPTION
## Summary
- Add simulation engine that processes work items daily, including scheduling, capacity and exit rules
- Track remaining complexity on items and persist it in snapshots and imports
- Drive simulation loop through new engine to advance items automatically

## Testing
- `node --check js/engine.mjs` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c014d385448331bd5c1abc768edf9e