### PR TITLE
Add simulation reset control

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <div class="brand"><div class="logo">🌀</div><div class="title">FlowSim <span class="tag">prototype</span></div></div>
     <div class="controls">
       <button id="playPauseBtn" class="btn primary">▶︎ Play</button>
+      <button id="resetBtn" class="btn">⟲ Reset</button>
       <label class="speed">Speed <input id="speed" type="range" min="0.25" max="8" step="0.25" value="1" /><span id="speedVal">1×</span></label>
       <button id="addRandomItemBtn" class="btn">+ Random Item</button>
       <button id="addItemBtn" class="btn">+ Workitem…</button>

--- a/js/main.mjs
+++ b/js/main.mjs
@@ -85,6 +85,15 @@ function wireUI(){
     togglePlay();
     $('#playPauseBtn').textContent = state.sim.playing ? '⏸ Pause' : '▶︎ Play';
   });
+  $('#resetBtn').addEventListener('click', () => {
+    loadSnapshot();
+    state.sim.playing = false;
+    $('#playPauseBtn').textContent = '▶︎ Play';
+    $('#simDay').textContent = String(Math.floor(state.sim.day));
+    renderSidebar();
+    renderGrid();
+    saveSnapshot();
+  });
   document.addEventListener('keydown', e => {
     if (e.code === 'Space' && !e.repeat && document.activeElement?.tagName !== 'INPUT' && document.activeElement?.tagName !== 'TEXTAREA'){
       e.preventDefault();


### PR DESCRIPTION
## Summary
- Add "Reset" button beside Play to restore simulation to initial state
- Wire reset handler to reload last saved snapshot and update UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c01d1c69e08331a1b2802e474f2efd