### PR TITLE
feat: add auto workitem rules

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,7 @@
     <div class="brand"><div class="logo">🌀</div><div class="title">FlowSim <span class="tag">prototype</span></div></div>
     <div class="controls">
       <button id="configBtn" class="btn ghost">⚙ Config</button>
+      <button id="rulesBtn" class="btn ghost">⚙ Rules</button>
       <button id="playPauseBtn" class="btn primary">▶︎ Play</button>
       <button id="resetBtn" class="btn">⟲ Reset</button>
       <label class="speed">Speed <input id="speed" type="range" min="0.25" max="8" step="0.25" value="1" /><span id="speedVal">1×</span></label>
@@ -51,6 +52,8 @@
   <dialog id="cellModal"></dialog>
   <!-- Configuration Modal -->
   <dialog id="configModal"></dialog>
+  <!-- Rule Config Modal -->
+  <dialog id="ruleModal"></dialog>
 
   <template id="itemTpl">
     <article class="wi" draggable="true" role="button" aria-label="Workitem">

--- a/js/engine.mjs
+++ b/js/engine.mjs
@@ -3,9 +3,26 @@ import { state, getCell, getWorkgroupSettings, groupFor } from './store.mjs';
 import { newItem } from './model.mjs';
 import { renderItemsIntoGrid } from './ui/grid.mjs';
 
+const randInt = (min,max)=>Math.floor(Math.random()*(max-min+1))+min;
+
 // Process a single simulation day
 export function processDay(day){
   let changed = false;
+  // Generate new items based on arrival rules
+  for (const rule of state.rules){
+    if (!rule.enabled) continue;
+    if (rule.nextDay === undefined) rule.nextDay = day;
+    if (day >= rule.nextDay){
+      const qty = randInt(rule.qtyMin, rule.qtyMax);
+      for (let i=0;i<qty;i++){
+        const size = randInt(rule.sizeMin, rule.sizeMax);
+        const complexity = randInt(rule.complexityMin, rule.complexityMax);
+        newItem({ type: rule.type, size, complexity, stateId: rule.stateId });
+      }
+      rule.nextDay = day + randInt(rule.freqMin, rule.freqMax);
+      changed = true;
+    }
+  }
   for (const g of state.groups){
     const sched = getWorkgroupSettings(g.id);
     if (day < sched.startDay) continue;

--- a/js/store.mjs
+++ b/js/store.mjs
@@ -6,6 +6,7 @@ export const state = {
   items: new Map(),    // id -> item
   types: [],          // ['Epic','Feature',...]
   nextId: 1,
+  rules: [],          // automatic arrival rules
 };
 
 export const TYPE_COLORS = { Epic:'#fde68a', Feature:'#93c5fd', Story:'#a7f3d0', Bug:'#fca5a5' };
@@ -78,6 +79,7 @@ export function saveSnapshot(){
     workgroupSettings: Array.from(workgroupSettings.entries()),
     types: state.types,
     nextId: state.nextId,
+    rules: state.rules,
   };
   localStorage.setItem('flowsim.v2', JSON.stringify(snap));
 }
@@ -100,6 +102,7 @@ export function loadSnapshot(){
     try { workgroupSettings.clear(); (s.workgroupSettings||[]).forEach(([k,v])=> workgroupSettings.set(k,v)); } catch {}
     state.types = s.types ?? [...ALL_TYPES];
     state.nextId = s.nextId ?? 1;
+    state.rules = s.rules ?? [];
     return true;
   }catch{ return false; }
 }

--- a/js/ui/autorules.mjs
+++ b/js/ui/autorules.mjs
@@ -1,0 +1,94 @@
+import { state, saveSnapshot, ALL_TYPES, uid } from '../store.mjs';
+
+const $ = s => document.querySelector(s);
+const h = (tag, props={}, children=[]) => {
+  const el = document.createElement(tag);
+  Object.entries(props).forEach(([k,v]) => {
+    if (k === 'class') el.className = v;
+    else if (k === 'dataset') Object.assign(el.dataset, v);
+    else if (k.startsWith('on') && typeof v === 'function') el.addEventListener(k.slice(2), v);
+    else if (v !== undefined) el.setAttribute(k, v);
+  });
+  if (!Array.isArray(children)) children = [children];
+  children.filter(Boolean).forEach(c => el.appendChild(typeof c === 'string' ? document.createTextNode(c) : c));
+  return el;
+};
+
+export function showRuleModal(){
+  renderRules();
+  $('#ruleModal').showModal();
+}
+
+export function renderRules(){
+  const dlg = $('#ruleModal');
+  if (!dlg.dataset.init){
+    dlg.dataset.init = '1';
+    const form = h('form', { method:'dialog' }, [
+      h('h3', {}, [
+        'Auto Workitem Rules ',
+        h('button', { type:'button', class:'iconBtn', id:'ruleHelp', title:'Help' }, '❔')
+      ]),
+      h('ul', { id:'ruleList', class:'list' }),
+      h('button', { class:'btn small', type:'button', id:'addRuleBtn' }, '+ Rule'),
+      h('menu', {}, [
+        h('button', { class:'btn ghost', value:'cancel' }, 'Close')
+      ])
+    ]);
+    dlg.appendChild(form);
+    form.querySelector('#addRuleBtn').addEventListener('click', () => {
+      const defaultState = state.states[0]?.id || '';
+      const defaultType = state.types[0] || ALL_TYPES[0];
+      state.rules.push({ id: uid(), enabled: true, freqMin:1, freqMax:1, qtyMin:1, qtyMax:1, stateId: defaultState, type: defaultType, sizeMin:1, sizeMax:5, complexityMin:1, complexityMax:5, nextDay: state.sim.day + 1 });
+      renderRules(); saveSnapshot();
+    });
+    form.querySelector('#ruleHelp').addEventListener('click', () => {
+      alert('Enable Rule – Toggle rule activation so users can draft without triggering generation.\nFrequency Interval – [minDays, maxDays] range; each generation randomly picks a day gap within the interval.\nQuantity Interval – [minItems, maxItems] range; batch size randomly chosen per generation.\nInitial State – Starting column for new items.\nType – Work-item category.\nSize Range – Min/max size for new items.\nComplexity Range – Min/max complexity for new items.');
+    });
+  }
+  const list = dlg.querySelector('#ruleList'); list.innerHTML='';
+  state.rules.forEach(rule => {
+    const li = h('li', { class:'rule' }, [
+      h('div', { class:'row', style:'justify-content:space-between;align-items:center' }, [
+        h('label', {}, [
+          h('input', { type:'checkbox', checked: rule.enabled, onchange: e=>{ rule.enabled=e.target.checked; saveSnapshot(); } }),
+          ' Enabled'
+        ]),
+        h('button', { class:'iconBtn danger', type:'button', title:'Delete', onclick:()=>{ state.rules = state.rules.filter(r=>r.id!==rule.id); renderRules(); saveSnapshot(); } }, '✕')
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'Frequency'),
+        h('input',{ type:'number', value:rule.freqMin, min:1, style:'width:60px', onchange:e=>{ rule.freqMin=Number(e.target.value)||1; saveSnapshot(); } }),
+        h('span',{},'to'),
+        h('input',{ type:'number', value:rule.freqMax, min:rule.freqMin, style:'width:60px', onchange:e=>{ rule.freqMax=Number(e.target.value)||rule.freqMin; saveSnapshot(); } }),
+        h('span',{},'days')
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'Quantity'),
+        h('input',{ type:'number', value:rule.qtyMin, min:1, style:'width:60px', onchange:e=>{ rule.qtyMin=Number(e.target.value)||1; saveSnapshot(); } }),
+        h('span',{},'to'),
+        h('input',{ type:'number', value:rule.qtyMax, min:rule.qtyMin, style:'width:60px', onchange:e=>{ rule.qtyMax=Number(e.target.value)||rule.qtyMin; saveSnapshot(); } })
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'State'),
+        h('select', { value:rule.stateId, onchange:e=>{ rule.stateId=e.target.value; saveSnapshot(); } }, state.states.map(s=>h('option',{value:s.id},s.name)))
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'Type'),
+        h('select', { value:rule.type, onchange:e=>{ rule.type=e.target.value; saveSnapshot(); } }, state.types.map(t=>h('option',{value:t},t)))
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'Size'),
+        h('input',{ type:'number', value:rule.sizeMin, min:1, style:'width:60px', onchange:e=>{ rule.sizeMin=Number(e.target.value)||1; saveSnapshot(); } }),
+        h('span',{},'to'),
+        h('input',{ type:'number', value:rule.sizeMax, min:rule.sizeMin, style:'width:60px', onchange:e=>{ rule.sizeMax=Number(e.target.value)||rule.sizeMin; saveSnapshot(); } })
+      ]),
+      h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
+        h('span',{},'Complexity'),
+        h('input',{ type:'number', value:rule.complexityMin, min:1, style:'width:60px', onchange:e=>{ rule.complexityMin=Number(e.target.value)||1; saveSnapshot(); } }),
+        h('span',{},'to'),
+        h('input',{ type:'number', value:rule.complexityMax, min:rule.complexityMin, style:'width:60px', onchange:e=>{ rule.complexityMax=Number(e.target.value)||rule.complexityMin; saveSnapshot(); } })
+      ])
+    ]);
+    list.appendChild(li);
+  });
+}


### PR DESCRIPTION
## Summary
- add persistent rules array for automatic work-item creation
- provide UI to configure rule frequency, quantity, and properties with inline help
- simulate arrivals based on rules and expose modal from new Rules button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c029d41ebc833198ad811204735399