### PR TITLE
Fix auto-rule interval labels

### DIFF
--- a/js/ui/autorules.mjs
+++ b/js/ui/autorules.mjs
@@ -56,14 +56,14 @@ export function renderRules(){
         h('button', { class:'iconBtn danger', type:'button', title:'Delete', onclick:()=>{ state.rules = state.rules.filter(r=>r.id!==rule.id); renderRules(); saveSnapshot(); } }, '✕')
       ]),
       h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
-        h('span',{},'Frequency'),
+        h('span',{},'Frequency Interval'),
         h('input',{ type:'number', value:rule.freqMin, min:1, style:'width:60px', onchange:e=>{ rule.freqMin=Number(e.target.value)||1; saveSnapshot(); } }),
         h('span',{},'to'),
         h('input',{ type:'number', value:rule.freqMax, min:rule.freqMin, style:'width:60px', onchange:e=>{ rule.freqMax=Number(e.target.value)||rule.freqMin; saveSnapshot(); } }),
         h('span',{},'days')
       ]),
       h('div', { class:'row', style:'margin-top:6px; gap:6px; align-items:center' }, [
-        h('span',{},'Quantity'),
+        h('span',{},'Quantity Interval'),
         h('input',{ type:'number', value:rule.qtyMin, min:1, style:'width:60px', onchange:e=>{ rule.qtyMin=Number(e.target.value)||1; saveSnapshot(); } }),
         h('span',{},'to'),
         h('input',{ type:'number', value:rule.qtyMax, min:rule.qtyMin, style:'width:60px', onchange:e=>{ rule.qtyMax=Number(e.target.value)||rule.qtyMin; saveSnapshot(); } })


### PR DESCRIPTION
## Summary
- Clarify auto-rule setup by labeling frequency and quantity inputs as intervals

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c032f09d8c8331b9f70193f9ed477b