### PR TITLE
Harden configuration loading and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,9 +3,11 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; script-src 'self'; img-src 'self'; connect-src 'self'; object-src 'none'" />
   <title>FlowSim — Modular Prototype</title>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <!-- Update integrity hash with: curl -s 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap' | openssl dgst -sha384 -binary | openssl base64 -A -->
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" integrity="sha384-OLBgp1GsljhM2TJ+sbHjaiH9txEUvgdDTAzHv2P24donTt6/529l+9Ua0vFImLlb" crossorigin="anonymous">
   <link rel="stylesheet" href="css/base.css">
   <link rel="stylesheet" href="css/grid.css">
   <link rel="stylesheet" href="css/card.css">

--- a/js/p2p.mjs
+++ b/js/p2p.mjs
@@ -1,4 +1,35 @@
 // p2p stub (API surface ready for WebRTC layer)
-export async function connect(){ await new Promise(r=>setTimeout(r,250)); console.log('[P2P] stub connect ok'); return true; }
-export function broadcast(topic, payload){ console.log('[P2P] broadcast', topic, payload); }
-export function on(topic, handler){ console.log('[P2P] on', topic, handler); }
+// Implementers should ensure peers are authenticated and messages validated.
+const allowedTopics = new Set();
+const MAX_MESSAGE_SIZE = 16 * 1024; // 16KB
+
+export async function connect(opts={}){
+  // TODO: establish WebRTC connection and verify peer credentials.
+  // Reject connections lacking proper authentication (e.g., shared secret or certificate).
+  await new Promise(r=>setTimeout(r,250));
+  console.log('[P2P] stub connect ok');
+  return true;
+}
+
+export function broadcast(topic, payload){
+  // Only allow known topics and bounded payloads to avoid abuse.
+  if (typeof topic !== 'string' || !allowedTopics.has(topic)){
+    console.warn('[P2P] blocked broadcast of unexpected topic', topic);
+    return;
+  }
+  const data = JSON.stringify(payload);
+  if (data.length > MAX_MESSAGE_SIZE){
+    console.warn('[P2P] message too large, dropped');
+    return;
+  }
+  // TODO: send data to peers with rate limiting to mitigate flooding attacks.
+  console.log('[P2P] broadcast', topic, payload);
+}
+
+export function on(topic, handler){
+  // Register a handler for an expected topic. Incoming messages should be
+  // validated for structure and size before invoking the handler.
+  if (typeof topic !== 'string' || typeof handler !== 'function') return;
+  allowedTopics.add(topic);
+  console.log('[P2P] on', topic, handler);
+}


### PR DESCRIPTION
## Summary
- render cell configuration modal with DOM APIs to avoid HTML injection
- validate imported configurations and local saves for size and structure
- add basic security headers and P2P stubs that enforce topic and size limits

## Testing
- `node --check js/ui/modal.mjs`
- `node --check js/main.mjs`
- `node --check js/p2p.mjs`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c040543ad48331a5e689708192ae84